### PR TITLE
Increase empty lines between methods from 1 to 2

### DIFF
--- a/recommended.cfj
+++ b/recommended.cfj
@@ -22,7 +22,7 @@
       "settings": {
         "EmptyLinesBetweenClasses": "2",
         "EmptyLinesBetweenClassAndMethod": "0",
-        "EmptyLinesBetweenMethods": "1"
+        "EmptyLinesBetweenMethods": "2"
       }
     },
     {

--- a/recommended.cfj
+++ b/recommended.cfj
@@ -1,7 +1,7 @@
 {
   "requiredVersion": 1,
   "programVersion": 26,
-  "ruleCount": 75,
+  "ruleCount": 98,
   "autoActivateNewFeatures": false,
   "rules": [
     {
@@ -36,6 +36,19 @@
         "RemoveEmptyLineBelowSections": "1",
         "MaxEmptyLines": "1",
         "AddLineBetweenDefTypes": "2"
+      }
+    },
+    {
+      "ruleID": "CDS_TEST_CLASS_LINES",
+      "isActive": false,
+      "settingCount": 6,
+      "settings": {
+        "RemoveToDoComments": "1",
+        "EmptyLineAboveInsertTestData": "1",
+        "RemoveAbapDoc": "1",
+        "EmptyLineBelowSelect": "1",
+        "EmptyLineAboveSelect": "1",
+        "MovePrepareMethods": "0"
       }
     },
     {
@@ -364,11 +377,12 @@
     {
       "ruleID": "VALUE_STATEMENT",
       "isActive": true,
-      "settingCount": 6,
+      "settingCount": 7,
       "settings": {
         "MoveIntegerLiterals": "1",
         "MoveFloatLiterals": "1",
         "MoveIdentifiers": "1",
+        "SkipIfRowsCommentedOut": "1",
         "MoveComplexExpressions": "1",
         "MoveMethodCalls": "0",
         "MoveStringLiterals": "1"
@@ -574,15 +588,30 @@
     {
       "ruleID": "CAMEL_CASE_NAME",
       "isActive": true,
-      "settingCount": 7,
+      "settingCount": 10,
       "settings": {
         "MinLengthOfSureMatch": "11",
         "ContextWithUnknownAction": "3",
+        "CustomViewNamesFile": "CustomViewNames.txt",
         "ContextAllKnownAction": "0",
+        "ProcessComments": "0",
         "RequireApprovalForSureMatch": "0",
         "ProcessFieldNames": "1",
+        "CustomFieldNamesFile": "CustomFieldNames.txt",
         "DeviationAction": "1",
         "ProcessViewNames": "1"
+      }
+    },
+    {
+      "ruleID": "CAMEL_CASE_IN_CDS_TEST",
+      "isActive": false,
+      "settingCount": 5,
+      "settings": {
+        "ProcessComments": "1",
+        "AddPseudoCommentNoWhere": "1",
+        "ProcessClassName": "1",
+        "ProcessVariableNames": "1",
+        "ProcessLiterals": "1"
       }
     },
     {
@@ -821,6 +850,298 @@
         "ParamCountAfterPerform": "3",
         "MaxLineLength": "120",
         "AlignWithFormName": "1"
+      }
+    },
+    {
+      "ruleID": "DDL_ANNO_LAYOUT",
+      "isActive": false,
+      "settingCount": 8,
+      "settings": {
+        "SpaceInsideBrackets": "1",
+        "MaxOneLinerElemCountMain": "4",
+        "AlignTablesInArrays": "1",
+        "AlignValues": "0",
+        "SpaceInsideBraces": "1",
+        "MaxOneLinerElemCountList": "4",
+        "SpaceAfterColon": "1",
+        "MaxLineLength": "120"
+      }
+    },
+    {
+      "ruleID": "DDL_ANNO_NESTING",
+      "isActive": false,
+      "settingCount": 6,
+      "settings": {
+        "NestingAllowList": "",
+        "NestingBlockList": "",
+        "EmptyLinesMain": "1",
+        "SortOrder": "1",
+        "EmptyLinesList": "3",
+        "NestingMinDepth": "1"
+      }
+    },
+    {
+      "ruleID": "DDL_POSITION_DEFINE",
+      "isActive": false,
+      "settingCount": 7,
+      "settings": {
+        "BreakBeforeDefine": "0",
+        "DefineIndent": "0",
+        "EntityNameIndent": "2",
+        "BreakBeforeEntityName": "2",
+        "ParamsIndent": "4",
+        "WithParamsIndent": "2",
+        "BreakBeforeWithParams": "0"
+      }
+    },
+    {
+      "ruleID": "DDL_POSITION_SELECT",
+      "isActive": false,
+      "settingCount": 8,
+      "settings": {
+        "BreakBeforeSelectFrom": "0",
+        "AsSelectFromIndent": "2",
+        "BreakBeforeAsSelectFrom": "0",
+        "BreakBeforeDataSource": "2",
+        "DataSourceIndent": "4",
+        "SelectFromIndent": "2",
+        "AsProjectionOnIndent": "2",
+        "BreakBeforeAsProjectionOn": "0"
+      }
+    },
+    {
+      "ruleID": "DDL_POSITION_JOIN",
+      "isActive": false,
+      "settingCount": 6,
+      "settings": {
+        "KeywordsIndent": "4",
+        "BreakBeforeCondition": "1",
+        "BreakBeforeKeywords": "0",
+        "BreakBeforeDataSource": "2",
+        "DataSourceIndent": "4",
+        "ConditionIndent": "6"
+      }
+    },
+    {
+      "ruleID": "DDL_POSITION_ASSOCIATION",
+      "isActive": false,
+      "settingCount": 8,
+      "settings": {
+        "KeywordsIndent": "2",
+        "BreakBeforeCondition": "1",
+        "BreakBeforeKeywords": "0",
+        "BreakBeforeDataSource": "2",
+        "DataSourceIndent": "2",
+        "ConditionIndent": "4",
+        "BreakBeforeFilter": "0",
+        "FilterIndent": "4"
+      }
+    },
+    {
+      "ruleID": "DDL_POSITION_BRACES",
+      "isActive": false,
+      "settingCount": 6,
+      "settings": {
+        "FromIndent": "2",
+        "BreakBeforeFrom": "0",
+        "BreakBeforeOpeningBrace": "0",
+        "ClosingBraceIndent": "0",
+        "OpeningBraceIndent": "0",
+        "BreakBeforeClosingBrace": "0"
+      }
+    },
+    {
+      "ruleID": "DDL_POSITION_CLAUSES",
+      "isActive": false,
+      "settingCount": 4,
+      "settings": {
+        "BreakBeforeUnionEtc": "0",
+        "UnionEtcIndent": "0",
+        "WhereEtcIndent": "0",
+        "BreakBeforeWhereEtc": "0"
+      }
+    },
+    {
+      "ruleID": "DDL_SPACES_AROUND_SIGNS",
+      "isActive": false,
+      "settingCount": 8,
+      "settings": {
+        "SpaceAroundArithmeticOps": "0",
+        "SpaceAfterCommaInAbapType": "2",
+        "SpaceBeforeCommentSign": "0",
+        "SpaceBeforeColon": "1",
+        "SpaceAfterCommentSign": "0",
+        "SpaceAfterColon": "0",
+        "SpaceAfterComma": "0",
+        "SpaceBeforeComma": "2"
+      }
+    },
+    {
+      "ruleID": "DDL_SPACES_AROUND_BRACKETS",
+      "isActive": false,
+      "settingCount": 9,
+      "settings": {
+        "SpacesInsidePathBrackets": "2",
+        "SpacesInsideCardBrackets": "2",
+        "SpacesAroundCardBrackets": "0",
+        "SpacesInsideArithParens": "2",
+        "SpacesBeforeFuncParens": "2",
+        "SpacesInsideFuncParens": "2",
+        "SpacesBeforeTypeParens": "2",
+        "SpacesBeforePathBrackets": "2",
+        "SpacesInsideTypeParens": "2"
+      }
+    },
+    {
+      "ruleID": "DDL_CAMEL_CASE_NAME",
+      "isActive": false,
+      "settingCount": 6,
+      "settings": {
+        "FixAliases": "1",
+        "OnlyApprovedNames": "1",
+        "RequireAllFieldsKnown": "1",
+        "FixFieldNames": "1",
+        "FixRefsInAnnotations": "1",
+        "FixEntityName": "1"
+      }
+    },
+    {
+      "ruleID": "DDL_TYPO",
+      "isActive": false,
+      "settingCount": 5,
+      "settings": {
+        "ProcessAnnotations": "1",
+        "ProcessComments": "1",
+        "ProcessAnnotationRefs": "0",
+        "CorrectTypos": "1",
+        "ConvertBritishToAmerican": "1"
+      }
+    },
+    {
+      "ruleID": "DDL_ALIGN_ENTITY_PARAMETERS",
+      "isActive": false,
+      "settingCount": 2,
+      "settings": {
+        "AlignColons": "1",
+        "AlignTypes": "1"
+      }
+    },
+    {
+      "ruleID": "DDL_ALIGN_SOURCE_PARAMETERS",
+      "isActive": false,
+      "settingCount": 4,
+      "settings": {
+        "ParameterPos": "3",
+        "AlignActualParams": "1",
+        "AlignAssignmentOps": "1",
+        "AsAliasPos": "0"
+      }
+    },
+    {
+      "ruleID": "DDL_ALIGN_FUNCTION_PARAMETERS",
+      "isActive": false,
+      "settingCount": 3,
+      "settings": {
+        "ParameterPos": "0",
+        "AlignActualParams": "1",
+        "AlignAssignmentOps": "1"
+      }
+    },
+    {
+      "ruleID": "DDL_ALIGN_LOGICAL_EXPRESSIONS",
+      "isActive": false,
+      "settingCount": 13,
+      "settings": {
+        "AlignFilterWithBoolOps": "2",
+        "AlignAssociationOn": "1",
+        "AlignPathExpressions": "1",
+        "AlignWhenWithBoolOps": "2",
+        "AlignWhere": "1",
+        "AlignOnWithBoolOps": "1",
+        "AlignHavingWithBoolOps": "2",
+        "AlignJoinOn": "1",
+        "AlignWhen": "1",
+        "RightAlignComparisonOps": "1",
+        "AlignHaving": "1",
+        "MaxInnerSpaces": "20",
+        "AlignWhereWithBoolOps": "2"
+      }
+    },
+    {
+      "ruleID": "DDL_ALIGN_FIELD_LISTS",
+      "isActive": false,
+      "settingCount": 7,
+      "settings": {
+        "SimpleGroupByListLayout": "0",
+        "NameListPos": "1",
+        "ComplexGroupByListLayout": "0",
+        "ConsiderDotAsComplex": "1",
+        "MaxLineLength": "120",
+        "NameListLayout": "0",
+        "GroupByListPos": "0"
+      }
+    },
+    {
+      "ruleID": "DDL_ALIGN_DATA_SOURCES",
+      "isActive": false,
+      "settingCount": 5,
+      "settings": {
+        "AlignDataSources": "1",
+        "AlignAssociationsWithJoins": "0",
+        "AlignOnConditions": "1",
+        "ConsiderAllParamAssignLines": "0",
+        "AlignAliases": "1"
+      }
+    },
+    {
+      "ruleID": "DDL_ALIGN_SELECT_LIST",
+      "isActive": false,
+      "settingCount": 8,
+      "settings": {
+        "ConsiderAllElementLines": "0",
+        "AlignCommentedOutCode": "1",
+        "ConsiderSimpleElementsWithoutAlias": "1",
+        "ConsiderComplexElementsWithoutAlias": "0",
+        "AlignTextualComments": "1",
+        "MaxAliasStart": "120",
+        "AlignAliases": "1",
+        "AlignKeyKeyword": "1"
+      }
+    },
+    {
+      "ruleID": "DDL_EMPTY_LINES_BETWEEN",
+      "isActive": false,
+      "settingCount": 10,
+      "settings": {
+        "BetweenEntityAnnosAndDefine": "0",
+        "BetweenParametersAndAsSelect": "0",
+        "BeforeSelectListStart": "0",
+        "AfterSelectListStart": "3",
+        "BetweenSelectFromAndJoins": "1",
+        "BetweenJoinsAndAssociations": "0",
+        "BeforeSelectListEnd": "3",
+        "AfterSelectListEnd": "0",
+        "MaxConsecutiveEmptyLines": "2",
+        "RemoveAtDocumentEnd": "1"
+      }
+    },
+    {
+      "ruleID": "DDL_EMPTY_LINES_WITHIN",
+      "isActive": false,
+      "settingCount": 12,
+      "settings": {
+        "SurroundAssociationLineCountMin": "2",
+        "CondenseParameters": "2",
+        "CondenseAssociations": "2",
+        "DetachExposedAssociations": "1",
+        "CondenseClauses": "3",
+        "SurroundParameterLineCountMin": "2",
+        "CondenseJoins": "2",
+        "DetachKeyFields": "1",
+        "CondenseElements": "2",
+        "SurroundJoinLineCountMin": "2",
+        "SurroundElementLineCountMin": "2",
+        "SurroundClauseLineCountMin": "2"
       }
     }
   ]


### PR DESCRIPTION
When a method implementation is edited using the SAP GUI, the empty lines between methods are always set to 2. This creates a constant back-and-forth when using SAP GUI and the ABAP Cleaner. 

Of course, there's a lot more back-and-forth when a class definition is edited using the SAP GUI, but that isn't something we can solve without making everything ugly. Increasing the number of empty lines between methods is a comparatively small price to pay for having less back-and-forth.