### PR TITLE
Update to v1.20.1

### DIFF
--- a/recommended.cfj
+++ b/recommended.cfj
@@ -509,11 +509,12 @@
     {
       "ruleID": "CONDENSE",
       "isActive": true,
-      "settingCount": 4,
+      "settingCount": 5,
       "settings": {
         "SpecifyFromForNoGaps": "1",
         "SpecifyValName": "0",
         "KeepParamsOnOneLine": "0",
+        "SkipUnknownTypes": "1",
         "SpecifyDel": "0"
       }
     },


### PR DESCRIPTION
The new option "Only replace CONDENSE for known structured types" for rule "Replace CONDENSE with string function" is active by default in v1.20.1.

(The new option is also active even if the shared profile wasn't updated.)